### PR TITLE
Implement Coding Keys

### DIFF
--- a/library-ios/Src/Controller/BookDetailViewController.swift
+++ b/library-ios/Src/Controller/BookDetailViewController.swift
@@ -34,7 +34,7 @@ class BookDetailViewController: UIViewController {
         
         bookTitle.text = book.title
         bookAuthor.text = book.author
-        coverThumbnailImage.load(URL(book.cover_image), defaultImage: "defaultBookImage")
+        coverThumbnailImage.load(URL(book.coverImage), defaultImage: "defaultBookImage")
     }
 
 }

--- a/library-ios/Src/Controller/BooksViewController.swift
+++ b/library-ios/Src/Controller/BooksViewController.swift
@@ -60,7 +60,7 @@ extension BooksViewController {
         
         cell.titleLabel.text = book.title
         cell.authorLabel.text = book.author
-        cell.coverThumbnailImage.load(URL(book.cover_image), defaultImage: "defaultBookImage")
+        cell.coverThumbnailImage.load(URL(book.coverImage), defaultImage: "defaultBookImage")
   
         return cell
     }

--- a/library-ios/Src/Model/Book.swift
+++ b/library-ios/Src/Model/Book.swift
@@ -13,6 +13,14 @@ struct Book: Codable {
     
     var title: String
     var author: String
-    var cover_image: String
+    var coverImage: String
     var id: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case title
+        case author
+        case id
+        case coverImage = "cover_image"
+    }
+    
 }


### PR DESCRIPTION
# Implement Coding Keys

## Changes
- Implement a `CodingKeys` enum in the `Book` struct so that we can use camel case (i.e. `coverImage`) in Swift even though the API is returning `cover_image`

See https://developer.apple.com/documentation/foundation/archives_and_serialization/encoding_and_decoding_custom_types:
> If the keys used in your serialized data format don't match the property names from your data type, provide alternative keys by specifying String as the raw-value type for the CodingKeys enumeration. 